### PR TITLE
Allow configuring bundler version; add a test-kitchen test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+.kitchen

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,29 @@
+---
+driver:
+  name: vagrant
+  customize:
+    cpus: 2
+    memory: 1024
+    cpuexecutioncap: 75
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+
+suites:
+  - name: testkitchen_ruby_ng_cookbook
+    run_list:
+      - recipe[ruby-ng_test]
+      - recipe[minitest-handler]
+    attributes:
+      minitest:
+        recipes:
+          - ruby-ng_test::default
+      ruby-ng:
+        ruby_version: 2.1
+        # 1.9.8 is the newest version as of 05/13/2015, but we are testing if we can install
+        # a specific older version.
+        bundler_version: 1.9.7
+        

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,8 @@
+source 'https://api.berkshelf.com'
+
+metadata
+
+group :integration do
+  cookbook 'minitest-handler'
+  cookbook 'ruby-ng_test', path: 'test/cookbooks/ruby-ng_test'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+group :integration do
+  gem 'berkshelf'
+  gem 'test-kitchen', '~> 1.3'
+  gem 'kitchen-vagrant'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,7 @@
 default['ruby-ng']['experimental'] = false
 default['ruby-ng']['ruby_version'] = '2.1'
+
+# If this is set to "latest", Bundler is upgraded to the latest version. If this is not set,
+# the existing (potentially outdated) version of Bundler is kept.
+default['ruby-ng']['bundler_version'] = 'latest'
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,14 @@ end
 
 package "ruby#{node['ruby-ng']['ruby_version']}"
 
+bundler_version = node['ruby-ng']['bundler_version']
+
 gem_package 'bundler' do
   gem_binary '/usr/bin/gem'
   options '-n /usr/bin'
+  if bundler_version == 'latest'
+    action :upgrade
+  elsif bundler_version
+    version bundler_version
+  end
 end

--- a/test/cookbooks/ruby-ng_test/files/default/tests/minitest/default_test.rb
+++ b/test/cookbooks/ruby-ng_test/files/default/tests/minitest/default_test.rb
@@ -1,0 +1,31 @@
+require_relative 'helpers'
+
+describe_recipe "ruby-ng::default" do
+  include Helpers::RubyNgTests
+
+  it 'Installs the ruby<version> package' do
+    package("ruby#{node['ruby-ng']['ruby_version']}").must_be_installed
+  end
+
+  # This test requires that node['ruby-ng']['bundler_version'] is set to a specific value, not to
+  # "latest".
+  it 'Installs the correct version of the bundler gem' do
+    cmd = 'gem list bundler'
+    gem_list_bundler_output = shell_out!(cmd).stdout
+    bundler_version = node['ruby-ng']['bundler_version']
+    assert(
+      gem_list_bundler_output.include?("bundler (#{bundler_version})"),
+      "Expected bundler version #{bundler_version} " \
+        "to be the only version reported in the results of command '#{cmd}'")
+  end
+end
+
+describe_recipe "ruby-ng::dev" do
+  it 'Installs the ruby<version>-dev package' do
+    package("ruby#{node['ruby-ng']['ruby_version']}-dev").must_be_installed
+  end
+
+  it 'Installs the build-essential package' do
+    package('build-essential').must_be_installed
+  end
+end

--- a/test/cookbooks/ruby-ng_test/files/default/tests/minitest/helpers.rb
+++ b/test/cookbooks/ruby-ng_test/files/default/tests/minitest/helpers.rb
@@ -1,0 +1,11 @@
+module Helpers
+  module RubyNgTests
+    require 'chef/mixin/shell_out'
+
+    include Chef::Mixin::ShellOut
+    include MiniTest::Chef::Assertions
+    include MiniTest::Chef::Context
+    include MiniTest::Chef::Resources
+  end
+end
+

--- a/test/cookbooks/ruby-ng_test/metadata.rb
+++ b/test/cookbooks/ruby-ng_test/metadata.rb
@@ -1,0 +1,6 @@
+name 'ruby-ng_test'
+description 'This cookbook is used with test-kitchen to test the parent cookbook, ruby-ng'
+version '0.1.0'
+
+depends 'ruby-ng'
+

--- a/test/cookbooks/ruby-ng_test/recipes/default.rb
+++ b/test/cookbooks/ruby-ng_test/recipes/default.rb
@@ -1,0 +1,2 @@
+include_recipe 'ruby-ng'
+include_recipe 'ruby-ng::dev'


### PR DESCRIPTION
An outdated version of bundler is installed without this.
