### PR TITLE
Allow exact Ruby package versions to be specified and held

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+.kitchen

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,12 +8,17 @@ driver:
 
 provisioner:
   name: chef_solo
+  require_chef_omnibus: 12
 
 platforms:
-  - name: ubuntu-12.04
+  - name: ubuntu-14.04
+    driver:
+      name: vagrant
+    driver_config:
+      gui: true
 
 suites:
-  - name: testkitchen_ruby_ng_cookbook
+  - name: testkitchen_ruby_ng_cookbook_default_versions
     run_list:
       - recipe[ruby-ng_test]
       - recipe[minitest-handler]
@@ -22,8 +27,19 @@ suites:
         recipes:
           - ruby-ng_test::default
       ruby-ng:
-        ruby_version: 2.1
-        # 1.9.8 is the newest version as of 05/13/2015, but we are testing if we can install
-        # a specific older version.
-        bundler_version: 1.9.7
-        
+        ruby_version: 2.3
+  - name: testkitchen_ruby_ng_cookbook_specific_versions
+    run_list:
+      - recipe[ruby-ng_test]
+      - recipe[minitest-handler]
+    attributes:
+      minitest:
+        recipes:
+          - ruby-ng_test::specific_versions
+      ruby-ng:
+        ruby_version: 2.3
+        ruby_package_version: "2.3.5-1bbox2~trusty1"
+        hold_ruby_packages: true
+        # 1.15.4 is the newest table version as of 09/21/2017, but we are testing
+        # if we can install a specific older version.
+        bundler_version: 1.15.3

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,29 @@
+---
+driver:
+  name: vagrant
+  customize:
+    cpus: 2
+    memory: 1024
+    cpuexecutioncap: 75
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+
+suites:
+  - name: testkitchen_ruby_ng_cookbook
+    run_list:
+      - recipe[ruby-ng_test]
+      - recipe[minitest-handler]
+    attributes:
+      minitest:
+        recipes:
+          - ruby-ng_test::default
+      ruby-ng:
+        ruby_version: 2.1
+        # 1.9.8 is the newest version as of 05/13/2015, but we are testing if we can install
+        # a specific older version.
+        bundler_version: 1.9.7
+        

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,8 @@
+source 'https://api.berkshelf.com'
+
+metadata
+
+group :integration do
+  cookbook 'minitest-handler'
+  cookbook 'ruby-ng_test', path: 'test/cookbooks/ruby-ng_test'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+group :integration do
+  gem 'berkshelf'
+  gem 'test-kitchen', '~> 1.3'
+  gem 'kitchen-vagrant'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,7 @@
 default['ruby-ng']['experimental'] = false
 default['ruby-ng']['ruby_version'] = '2.1'
+
+# If this is set to "latest", Bundler is upgraded to the latest version. If this is not set,
+# the existing (potentially outdated) version of Bundler is kept.
+default['ruby-ng']['bundler_version'] = 'latest'
+

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,11 @@ default['ruby-ng']['ruby_version'] = '2.1'
 # the existing (potentially outdated) version of Bundler is kept.
 default['ruby-ng']['bundler_version'] = 'latest'
 
+# Likewise for the ruby packages themselves. However, this setting
+# defaults to keeping the first version installed.
+default['ruby-ng']['ruby_package_version'] = nil
+
+# Whether to hold the ruby package(s) after installation. Holding
+# prevents the packages from being upgraded externally, e.g.
+# when running apt-get update at the CLI.
+default['ruby-ng']['hold_ruby_packages'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'maciej@3ofcoins.net'
 license          'MIT'
 description      'Installs Ruby from brightbox/ruby-ng PPA'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.4.0'
 
 supports 'ubuntu'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,22 @@ apt_preference 'ruby-ng-02-enable_for_ruby' do
   pin_priority '666'
 end
 
-package "ruby#{node['ruby-ng']['ruby_version']}"
+v = node['ruby-ng']['ruby_version']
+
+execute "hold ruby#{v} package" do
+  command "apt-mark hold ruby#{v}"
+  action  :nothing
+end
+
+package "ruby#{v}" do
+  if node['ruby-ng']['ruby_package_version']
+    version node['ruby-ng']['ruby_package_version']
+  end
+
+  if node['ruby-ng']['hold_ruby_packages']
+    notifies :run, "execute[hold ruby#{v} package]", :immediate
+  end
+end
 
 bundler_version = node['ruby-ng']['bundler_version']
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,14 @@ end
 
 package "ruby#{node['ruby-ng']['ruby_version']}"
 
+bundler_version = node['ruby-ng']['bundler_version']
+
 gem_package 'bundler' do
   gem_binary '/usr/bin/gem'
   options '-n /usr/bin'
+  if bundler_version == 'latest'
+    action :upgrade
+  elsif bundler_version
+    version bundler_version
+  end
 end

--- a/recipes/dev.rb
+++ b/recipes/dev.rb
@@ -1,4 +1,19 @@
 include_recipe 'build-essential'
 include_recipe 'ruby-ng::default'
 
-package "ruby#{node['ruby-ng']['ruby_version']}-dev"
+v = node['ruby-ng']['ruby_version']
+
+execute "hold ruby#{v}-dev package" do
+  command "apt-mark hold ruby#{v}-dev"
+  action  :nothing
+end
+
+package "ruby#{v}-dev" do
+  if node['ruby-ng']['ruby_package_version']
+    version node['ruby-ng']['ruby_package_version']
+  end
+
+  if node['ruby-ng']['hold_ruby_packages']
+    notifies :run, "execute[hold ruby#{v}-dev package]", :immediate
+  end
+end

--- a/test/cookbooks/ruby-ng_test/files/default/tests/minitest/default_test.rb
+++ b/test/cookbooks/ruby-ng_test/files/default/tests/minitest/default_test.rb
@@ -7,16 +7,8 @@ describe_recipe "ruby-ng::default" do
     package("ruby#{node['ruby-ng']['ruby_version']}").must_be_installed
   end
 
-  # This test requires that node['ruby-ng']['bundler_version'] is set to a specific value, not to
-  # "latest".
-  it 'Installs the correct version of the bundler gem' do
-    cmd = 'gem list bundler'
-    gem_list_bundler_output = shell_out!(cmd).stdout
-    bundler_version = node['ruby-ng']['bundler_version']
-    assert(
-      gem_list_bundler_output.include?("bundler (#{bundler_version})"),
-      "Expected bundler version #{bundler_version} " \
-        "to be the only version reported in the results of command '#{cmd}'")
+  it 'Installs the bundler gem' do
+    shell_out!('gem list bundler').stdout.must_match(/bundler \(/)
   end
 end
 

--- a/test/cookbooks/ruby-ng_test/files/default/tests/minitest/default_test.rb
+++ b/test/cookbooks/ruby-ng_test/files/default/tests/minitest/default_test.rb
@@ -1,0 +1,31 @@
+require_relative 'helpers'
+
+describe_recipe "ruby-ng::default" do
+  include Helpers::RubyNgTests
+
+  it 'Installs the ruby<version> package' do
+    package("ruby#{node['ruby-ng']['ruby_version']}").must_be_installed
+  end
+
+  # This test requires that node['ruby-ng']['bundler_version'] is set to a specific value, not to
+  # "latest".
+  it 'Installs the correct version of the bundler gem' do
+    cmd = 'gem list bundler'
+    gem_list_bundler_output = shell_out!(cmd).stdout
+    bundler_version = node['ruby-ng']['bundler_version']
+    assert(
+      gem_list_bundler_output.include?("bundler (#{bundler_version})"),
+      "Expected bundler version #{bundler_version} " \
+        "to be the only version reported in the results of command '#{cmd}'")
+  end
+end
+
+describe_recipe "ruby-ng::dev" do
+  it 'Installs the ruby<version>-dev package' do
+    package("ruby#{node['ruby-ng']['ruby_version']}-dev").must_be_installed
+  end
+
+  it 'Installs the build-essential package' do
+    package('build-essential').must_be_installed
+  end
+end

--- a/test/cookbooks/ruby-ng_test/files/default/tests/minitest/helpers.rb
+++ b/test/cookbooks/ruby-ng_test/files/default/tests/minitest/helpers.rb
@@ -1,0 +1,11 @@
+module Helpers
+  module RubyNgTests
+    require 'chef/mixin/shell_out'
+
+    include Chef::Mixin::ShellOut
+    include MiniTest::Chef::Assertions
+    include MiniTest::Chef::Context
+    include MiniTest::Chef::Resources
+  end
+end
+

--- a/test/cookbooks/ruby-ng_test/files/default/tests/minitest/specific_versions_test.rb
+++ b/test/cookbooks/ruby-ng_test/files/default/tests/minitest/specific_versions_test.rb
@@ -1,0 +1,41 @@
+require_relative 'helpers'
+
+describe_recipe "ruby-ng::default" do
+  include Helpers::RubyNgTests
+
+  it 'Installs the ruby<version> package' do
+    package("ruby#{node['ruby-ng']['ruby_version']}").must_be_installed.with(:version, [node['ruby-ng']['ruby_package_version']])
+  end
+
+  it 'holds the ruby<version>-dev package' do
+    shell_out!('apt-mark showhold').stdout.must_match("ruby#{node['ruby-ng']['ruby_version']}-dev")
+  end
+
+  # This test requires that node['ruby-ng']['bundler_version'] is set to a specific value, not to
+  # "latest".
+  it 'Installs the correct version of the bundler gem' do
+    cmd = 'gem list bundler'
+    gem_list_bundler_output = shell_out!(cmd).stdout
+    bundler_version = node['ruby-ng']['bundler_version']
+    assert(
+      gem_list_bundler_output.include?("bundler (#{bundler_version})"),
+      "Expected bundler version #{bundler_version} " \
+        "to be the only version reported in the results of command '#{cmd}'")
+  end
+end
+
+describe_recipe "ruby-ng::dev" do
+  include Helpers::RubyNgTests
+
+  it 'Installs the ruby<version>-dev package' do
+    package("ruby#{node['ruby-ng']['ruby_version']}-dev").must_be_installed.with(:version, [node['ruby-ng']['ruby_package_version']])
+  end
+
+  it 'holds the ruby<version>-dev package' do
+    shell_out!('apt-mark showhold').stdout.must_match("ruby#{node['ruby-ng']['ruby_version']}-dev")
+  end
+
+  it 'Installs the build-essential package' do
+    package('build-essential').must_be_installed
+  end
+end

--- a/test/cookbooks/ruby-ng_test/metadata.rb
+++ b/test/cookbooks/ruby-ng_test/metadata.rb
@@ -1,0 +1,6 @@
+name 'ruby-ng_test'
+description 'This cookbook is used with test-kitchen to test the parent cookbook, ruby-ng'
+version '0.1.0'
+
+depends 'ruby-ng'
+

--- a/test/cookbooks/ruby-ng_test/recipes/default.rb
+++ b/test/cookbooks/ruby-ng_test/recipes/default.rb
@@ -1,0 +1,2 @@
+include_recipe 'ruby-ng'
+include_recipe 'ruby-ng::dev'


### PR DESCRIPTION
Allows the user to specify an exact BrightBox Ruby PPA package version to install, and optionally, to hold with `apt-mark hold`.

This is dependent on https://github.com/3ofcoins/chef-cookbook-ruby-ng/pull/1 as well.