### PR TITLE
Add testing, require modern Chef, default to 2.5

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+*.rbc
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+*_Store
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+*.tmp
+*.bk
+*.bkup
+
+# ruby/bundler files
+.ruby-version
+.ruby-gemset
+.rvmrc
+Gemfile.lock
+.bundle
+*.gem
+
+# YARD artifacts
+.yardoc
+_yardoc
+doc/
+.idea
+
+# chef stuff
+Berksfile.lock
+.kitchen
+.kitchen.local.yml
+vendor/
+.coverage/
+.zero-knife.rb
+Policyfile.lock.json
+
+# vagrant stuff
+.vagrant/
+.vagrant.d/
+.kitchen/

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,36 @@
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  deprecations_as_errors: true
+
+verifier:
+  name: inspec
+
+platforms:
+- name: ubuntu-14.04
+  driver:
+    image: dokken/ubuntu-14.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: ubuntu-16.04
+  driver:
+    image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: ubuntu-18.04
+  driver:
+    image: dokken/ubuntu-18.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,16 @@
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  deprecations_as_errors: true
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+  - name: ubuntu-18.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[ruby-ng::default]

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,25 @@
-Changes
-=======
+# Changes
 
-0.3.0
------
+## 1.0.0
 
- - Drop `install_ruby_dev` attribute, add `ruby-ng::dev` recipe instead
+- Default to Ruby 2.5
+- Require Chef 13.3+ and remove the need for the apt cookbook
+- Depend on build-essential 5.0+ cookbook and use the build_essential resource instead of thee recipe for improvements on Chef 14+
+- Add Test Kitchen configs for testing
+- Add chef_version, issues_url, and source_url metadata to the metadata.rb file
+- Add a chefignore file to limit what files are uploaded to the Chef Server.
+- Add a Berksfile
 
-0.2.0
------
+## 0.3.0
 
- - Default to Ruby 2.1
- - Switch to install ruby-dev
- - Don't install rubygems package
+- Drop `install_ruby_dev` attribute, add `ruby-ng::dev` recipe instead
 
+## 0.2.0
 
-0.1.1 and before
-----------------
+- Default to Ruby 2.1
+- Switch to install ruby-dev
+- Don't install rubygems package
+
+## 0.1.1 and before
+
 (history would need to be reconstructed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Default to Ruby 2.5
 - Require Chef 13.3+ and remove the need for the apt cookbook
 - Depend on build-essential 5.0+ cookbook and use the build_essential resource instead of thee recipe for improvements on Chef 14+
-- Add Test Kitchen configs for testing
+- Add Test Kitchen & Delivery local mode configs for testing
+- Add a basic ChefSpec setup
 - Add chef_version, issues_url, and source_url metadata to the metadata.rb file
 - Add a chefignore file to limit what files are uploaded to the Chef Server.
 - Add a Berksfile

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
-ruby-ng
-=======
+# ruby-ng Cookbook
 
-Installs Ruby from https://launchpad.net/~brightbox/+archive/ruby-ng
+Installs Ruby from <https://launchpad.net/~brightbox/+archive/ruby-ng>
 
-Requirements
-------------
+## Requirements
 
-Platform: Ubuntu
+### Platform:
 
-Cookbooks:
- - `apt`
- - `build-essential` (included by `ruby-ng::dev` recipe)
+- Ubuntu
 
-Recipes
--------
+### Cookbooks:
 
- - `ruby-ng::default` (`ruby-ng`) - installs Ruby runtime
- - `ruby-ng::dev` - installs Ruby runtime and development libraries
+- `build-essential` (included by `ruby-ng::dev` recipe)
 
-Attributes
-----------
+### Chef
 
- - `ruby-ng::experimental` (default: false) - use `ruby-ng-experimental` PPA
- - `ruby-ng::ruby_version` (default: 2.1) - Ruby version to install
+- Chef 13.3+
 
-License and Authors
--------------------
-Authors: Maciej Pasternacki <maciej@3ofcoins.net>
-License: MIT
+## Recipes
+
+- `ruby-ng::default` (`ruby-ng`) - installs Ruby runtime
+- `ruby-ng::dev` - installs Ruby runtime and development libraries
+
+## Attributes
+
+- `ruby-ng::experimental` (default: false) - use `ruby-ng-experimental` PPA
+- `ruby-ng::ruby_version` (default: 2.1) - Ruby version to install
+
+## License and Authors
+
+Authors: Maciej Pasternacki [maciej@3ofcoins.net](mailto:maciej@3ofcoins.net) License: MIT

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
 default['ruby-ng']['experimental'] = false
-default['ruby-ng']['ruby_version'] = '2.1'
+default['ruby-ng']['ruby_version'] = '2.5'

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,92 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+.travis.yml
+.foodcritic
+appveyor.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'MIT'
 description      'Installs Ruby from brightbox/ruby-ng PPA'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.0'
+source_url       'https://github.com/3ofcoins/chef-cookbook-ruby-ng'
+issues_url       'https://github.com/3ofcoins/chef-cookbook-ruby-ng/issues'
 
 supports 'ubuntu'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'maciej@3ofcoins.net'
 license          'MIT'
 description      'Installs Ruby from brightbox/ruby-ng PPA'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '1.0.0'
 chef_version     '>= 13.3'
 source_url       'https://github.com/3ofcoins/chef-cookbook-ruby-ng'
 issues_url       'https://github.com/3ofcoins/chef-cookbook-ruby-ng/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,10 +5,10 @@ license          'MIT'
 description      'Installs Ruby from brightbox/ruby-ng PPA'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.0'
+chef_version     '>= 13.3'
 source_url       'https://github.com/3ofcoins/chef-cookbook-ruby-ng'
 issues_url       'https://github.com/3ofcoins/chef-cookbook-ruby-ng/issues'
 
 supports 'ubuntu'
 
-depends 'apt'
 depends 'build-essential', '>= 5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ version          '0.3.0'
 supports 'ubuntu'
 
 depends 'apt'
-depends 'build-essential'
+depends 'build-essential', '>= 5.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,3 @@
-include_recipe 'apt'
-
 name = "ruby-ng#{'-experimental' if node['ruby-ng']['experimental']}"
 
 apt_repository "brightbox-#{name}" do

--- a/recipes/dev.rb
+++ b/recipes/dev.rb
@@ -1,4 +1,5 @@
-include_recipe 'build-essential'
+build_essential 'install compilation tools'
+
 include_recipe 'ruby-ng::default'
 
 package "ruby#{node['ruby-ng']['ruby_version']}-dev"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.color = true               # Use color in STDOUT
+  config.formatter = :documentation # Use the specified formatter
+  config.log_level = :error         # Avoid deprecation notice SPAM
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'default recipe on ubuntu 16.04' do
+  let(:runner) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') }
+  let(:chef_run) { runner.converge('ruby-ng::default') }
+
+  it 'converges successfully' do
+    expect { :chef_run }.to_not raise_error
+  end
+end


### PR DESCRIPTION
Add testing configs for Test Kitchen, ChefSpec, and Delivery local mode
Require Chef 13.3+ so we no longer need the apt cookbook
Resolve all the foodcritic warnings
Default to Ruby 2.5
Require modern build-essential cookbook so we can use the resource not the recipe
Bump for a 1.0 release
